### PR TITLE
Add new package_utils submodule for building package names

### DIFF
--- a/python/distant_vfx/farm/jobs/distant_slate/job.py
+++ b/python/distant_vfx/farm/jobs/distant_slate/job.py
@@ -16,6 +16,8 @@ class DistantSlateFarmJob(nuke_quicktime_render.NukeQuickTimeRenderFarmJob):
     ):
         if "nukescript_path" not in kwargs:
             kwargs["nukescript_path"] = self.NUKESCRIPT_PATH
+        if "first_frame" in kwargs:
+            kwargs["first_frame"] = kwargs.get("first_frame") - 1
 
         super(DistantSlateFarmJob, self).__init__(**kwargs)
 

--- a/python/distant_vfx/package_utils/__init__.py
+++ b/python/distant_vfx/package_utils/__init__.py
@@ -1,0 +1,1 @@
+from .utils import get_or_create_edit_package_directory

--- a/python/distant_vfx/package_utils/utils.py
+++ b/python/distant_vfx/package_utils/utils.py
@@ -7,6 +7,10 @@ EDIT_VENDOR_NAME = "edt"
 INTERNAL_MAILBOX_TEMPLATE = "{direction}_{vendor}"
 MAILBOX_PACKAGE_NAME_TEMPLATE_BASE = "{vendor}_{source_vendor}_{date}_%s"
 
+def directory_is_larger_than(directory, maxsize):
+    # Not implemented
+    return False
+
 
 def _build_internal_mailbox_name(direction="to", vendor=None):
     if direction not in ("to", "from"):

--- a/python/distant_vfx/package_utils/utils.py
+++ b/python/distant_vfx/package_utils/utils.py
@@ -1,0 +1,80 @@
+import datetime
+import os
+
+
+PREFIX = "/mnt/Projects/dst/mailbox"
+EDIT_VENDOR_NAME = "edt"
+INTERNAL_MAILBOX_TEMPLATE = "{direction}_{vendor}"
+MAILBOX_PACKAGE_NAME_TEMPLATE_BASE = "{vendor}_{source_vendor}_{date}_%s"
+
+
+def _build_internal_mailbox_name(direction="to", vendor=None):
+    if direction not in ("to", "from"):
+        raise ValueError("direction kwarg must be one of (\"to\", \"from\")")
+    if vendor is None:
+        raise ValueError("vendor kwarg must not be None")
+    return INTERNAL_MAILBOX_TEMPLATE.format(direction=direction, vendor=vendor)
+
+
+def _find_next_package_letter_name(directory, base_name, maxsize=None):
+    for x in range(97, 123):
+        # a - z
+        finalized_package_name = base_name % chr(x)
+        path = os.path.join(directory, finalized_package_name)
+        if os.path.exists(path):
+            if maxsize:
+                if directory_is_larger_than(path, maxsize):
+                    continue
+                # Directory has room
+                return finalized_package_name
+    return None
+
+def _build_mailbox_package_name(directory, vendor, source_vendor, date, maxsize=None):
+    base_package_name = MAILBOX_PACKAGE_NAME_TEMPLATE_BASE.format(
+        vendor=vendor,
+        source_vendor=source_vendor,
+        date=date,
+    )
+    package_letter_name = _find_next_package_letter_name(directory, base_package_name, maxsize=maxsize)
+    if package_letter_name:
+        return package_letter_name
+
+    # There are already 26 for today.
+    for x in range(97, 123):
+        # a - z
+        base_package_name = base_package_name % chr(x) + "%s"
+        package_letter_name = _find_next_package_letter_name(
+            directory,
+            base_package_name,
+            maxsize=maxsize
+        )
+        if package_letter_name:
+            return package_letter_name
+    # If we get to here, we need more than 2 digits for letters...And something is probably wrong.
+    raise ValueError("Could not find suitable packagename in 2 alphanumeric bytes. Confirm that things aren't weird")
+
+
+def get_or_create_edit_package_directory(direction="to", source_vendor="dst", date=None):
+    if direction not in ("to", "from"):
+        raise ValueError("direction kwarg must be one of (\"to\", \"from\")")
+    if date is None:
+        date = datetime.date.today().strftime("%Y%m%d")
+
+    base_directory = os.path.join(
+        PREFIX,
+        EDIT_VENDOR_NAME,
+        _build_internal_mailbox_name(
+            direction=direction, vendor=EDIT_VENDOR_NAME
+        ),
+    )
+    package_directory = os.path.join(
+        base_directory,
+        _build_mailbox_package_name(
+            base_directory,
+            vendor=EDIT_VENDOR_NAME, source_vendor=source_vendor, date=date
+        )
+    )
+
+    if not os.path.exists(package_directory):
+        os.makedirs(package_directory)
+    return package_directory


### PR DESCRIPTION
Quick submodule that I need implemented.

distant_vfx.package_utils

Main exported function is `get_or_create_edit_package_directory(direction="to", source_vendor="dst", date=None)`

It will build an "edt" package folder. 
It current has the internals for a `maxsize` for each folder but I have not implemented it.


Expected usage is similar to:
```python
import os
import shutil

from distant_vfx.package_utils import get_or_create_edit_package_directory

path_for_ray = "/tmp/mypath.mov"
basename = os.path.basename(path_for_ray)

package_dir = get_or_create_edit_package_directory()
# /mnt/Projects/dst/mailbox/edt/to_edt/edt_dst_20201201_a

shutil.copy2(
    path_for_ray,
    os.path.join(package_dir, basename)
)
```


