### PR TITLE
Updates to distant_quicktime

### DIFF
--- a/python/distant_quicktime/colour/utilities.py
+++ b/python/distant_quicktime/colour/utilities.py
@@ -124,17 +124,75 @@ def search_for_cube_by_descriptor(descriptor, plates, root_dir):
 
 
 def _path_get_shot_lut_from_path(path):
+    "/mnt/Projects/dst/post/shot/efp/efp0630/script/nuke/efp0630_tmpComp_ignore_v001.ahughes.nk"
+    "/mnt/Projects/dst/post/shot/vpd/vpd0070/plate/vpd0070_bg01_v001/2156x1500_exr/vpd0070_bg01_v001.%04d.exr"
     "/mnt/Projects/dst/post/shot/vpd/vpd0070/shot/vpd0070_comp_v003/2156x1500_exr/vpd0070_comp_v003.%04d.exr"
-    "/mnt/Projects/dst/post/shot/ftc/ftc0200"
-    "/mnt/Projects/dst/post/scan/ftc1000_bg_v001/_cdl/versioned/ftc1000_bg_v001/luts/ftc1000_bg_v001.cube"
 
-    "/mnt/Projects/dst/post/shot/ftc/ftc1000/shot/ftc1000_comp_v001/2156x1500_exr/ftc1000_comp_v001.%04d.exr"
     "/mnt/Projects/dst/post/shot/ftc/ftc1000/plate/ftc1000_bg_v001/_cdl/versioned/ftc1000_bg_v001/luts/ftc1000_bg_v001.cube"
-    dirname_three = os.path.dirname(os.path.dirname(os.path.dirname(path)))
+    dirname_two = os.path.dirname(os.path.dirname(path))
+    dirname_three = os.path.dirname(dirname_two)
     version_folder_name = os.path.basename(os.path.dirname(os.path.dirname(path)))
+    print(dirname_three)
     if os.path.basename(dirname_three) == "shot":
         # We're dealing with a rendered image!
         shot_dir = os.path.dirname(dirname_three)
+        plates_dir = os.path.join(shot_dir, "plate")
+        plates = {}
+        for folder_name in os.listdir(plates_dir):
+            data_struct = descriptor_from_filename(folder_name)
+            descriptor = data_struct.get("descriptor")
+            version = data_struct.get("version")
+            if descriptor not in plates:
+                plates[descriptor] = {}
+
+            if version not in plates[descriptor]:
+                plates[descriptor][version] = {}
+
+            plates[descriptor][version] = data_struct
+
+        if "bg" in plates:
+            # Use the bg first
+            cube_path = search_for_cube_by_descriptor(
+                descriptor="bg",
+                plates=plates,
+                root_dir=plates_dir
+            )
+            if cube_path:
+                return cube_path
+        for descriptor in plates:
+            cube_path = search_for_cube_by_descriptor(
+                descriptor=descriptor,
+                plates=plates,
+                root_dir=plates_dir
+            )
+            if cube_path:
+                return cube_path
+
+        # Can't find it in the plate dir. I guess we check the scan one. Legacy bug.
+        data_struct_from_version_folder = descriptor_from_filename(version_folder_name)
+        cube_path = _find_cube_path_from_scan_dir(
+            version_folder_data=data_struct_from_version_folder,
+        )
+        return cube_path
+    elif os.path.basename(dirname_three) == "plate":
+        plates = {}
+        folder_name = os.path.basename(dirname_two)
+        data_struct = descriptor_from_filename(folder_name)
+        descriptor = data_struct.get("descriptor")
+        version = data_struct.get("version")
+        plates[descriptor] = {}
+        plates[descriptor][version] = data_struct
+
+        cube_path = search_for_cube_by_descriptor(
+            descriptor=descriptor,
+            plates=plates,
+            root_dir=dirname_three,
+        )
+        return cube_path
+
+    elif os.path.basename(dirname_two) == "script":
+        # We're dealing with a scene file!
+        shot_dir = os.path.dirname(dirname_two)
         plates_dir = os.path.join(shot_dir, "plate")
         plates = {}
         for folder_name in os.listdir(plates_dir):
@@ -191,8 +249,8 @@ def _path_get_show_lut_from_path(path):
 
 
 def get_show_lut_from_path(path):
-    return _path_get_shot_lut_from_path(path)
+    return _path_get_show_lut_from_path(path)
 
 
 def get_shot_lut_from_path(path):
-    return _path_get_show_lut_from_path(path)
+    return _path_get_shot_lut_from_path(path)

--- a/python/distant_quicktime/farm/jobs/distant_dnx115/template.nk
+++ b/python/distant_quicktime/farm/jobs/distant_dnx115/template.nk
@@ -205,6 +205,7 @@ Dot {
 Write {
  file "\[argv 1]"
  colorspace sRGB
+ file_type mov
  mov64_codec AVdn
  mov64_dnxhd_codec_profile "DNxHD 422 8-bit 145Mbit"
  mov_h264_codec_profile "High 4:2:0 8-bit"

--- a/python/distant_quicktime/farm/jobs/distant_dnx115/template.nk
+++ b/python/distant_quicktime/farm/jobs/distant_dnx115/template.nk
@@ -52,7 +52,7 @@ Vectorfield {
  ypos -229
 }
 Vectorfield {
- vfield_file /mnt/dst/mailbox/technicolor/fr_technicolor/20200910_a/dis_20767_jc_PHS_trim_scd60_rec709.cube
+ vfield_file /mnt/Projects/dst/post/admin/workflow/colour/dis_20767_jc_PHS_trim_scd60_rec709.cube
  version 10
  file_type cube
  colorspaceOut rec709

--- a/python/distant_quicktime/farm/jobs/distant_h264/template.nk
+++ b/python/distant_quicktime/farm/jobs/distant_h264/template.nk
@@ -205,12 +205,11 @@ Dot {
 Write {
  file "\[argv 1]"
  colorspace sRGB
- mov64_format "mov (QuickTime / MOV)"
+ file_type mov
  mov64_codec h264
  mov_h264_codec_profile "High 4:2:0 8-bit"
  mov64_pixel_format {{0} "yuv420p\tYCbCr 4:2:0 8-bit"}
  mov64_quality High
- mov64_advanced 1
  mov64_fast_start true
  mov64_write_timecode true
  mov64_gop_size 12
@@ -223,6 +222,6 @@ Write {
  checkHashOnRead false
  name Write
  selected true
- xpos -215
- ypos 348
+ xpos -40
+ ypos 260
 }

--- a/python/distant_quicktime/farm/jobs/distant_h264/template.nk
+++ b/python/distant_quicktime/farm/jobs/distant_h264/template.nk
@@ -52,7 +52,7 @@ Vectorfield {
  ypos -85
 }
 Vectorfield {
- vfield_file /mnt/dst/mailbox/technicolor/fr_technicolor/20200910_a/dis_20767_jc_PHS_trim_scd60_rec709.cube
+ vfield_file /mnt/Projects/dst/post/admin/workflow/colour/dis_20767_jc_PHS_trim_scd60_rec709.cube
  version 9
  file_type cube
  colorspaceOut rec709

--- a/python/distant_quicktime/package_utils/utils.py
+++ b/python/distant_quicktime/package_utils/utils.py
@@ -31,7 +31,9 @@ def _find_next_package_letter_name(directory, base_name, maxsize=None):
                     continue
                 # Directory has room
                 return finalized_package_name
+        return path
     return None
+
 
 def _build_mailbox_package_name(directory, vendor, source_vendor, date, maxsize=None):
     base_package_name = MAILBOX_PACKAGE_NAME_TEMPLATE_BASE.format(


### PR DESCRIPTION
Update EDT folder creation code from package_utils
  - This now works correctly and ingestpackage will automatically move dnx files over.

Add support for resolving colour files from nukescript scene files and plates in addition to the renders.
  - This was needed for our ApplyCDL gizmo.

Update the path to the ShowLUT in the quicktime templates.
  - This was changed live a while ago but I didn't move the change back into git.