### PR TITLE
Add an additional filename query

### DIFF
--- a/python/distant_vfx/screening.py
+++ b/python/distant_vfx/screening.py
@@ -199,7 +199,7 @@ class FastFindMovie(Screening):
         return FMP_VERSIONS_LAYOUT
 
     def _set_query(self):
-        return {'VFXID': self.vfxid}
+        return {'VFXID': self.vfxid, "Filename": "{}_*_*".format(self.vfxid)}
 
     @staticmethod
     def _get_cut_order_from_record(record):


### PR DESCRIPTION
Harrison is having an issue where it would return a lineup instead of a comp or whatever, so this might help?

If not, I will have to ask for more and then client side filter to remove lineups